### PR TITLE
Added on/off Google captcha in settings.ini

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -8,3 +8,7 @@ queue_path = /opt/kaptive/queue/
 [General]
 job_waiting_time = 60
 refresh_waiting_time = 60000
+
+[Security]
+#yes: enable, no: disable captcha
+captcha = yes


### PR DESCRIPTION
Disabling reCAPTCHA by hardcode deleting captcha_field() is not convenient. So I changed a bit so that we can switch it on/off in the settings.ini